### PR TITLE
fixed chsh documentation and formatting

### DIFF
--- a/reference/static/commands/shells/chsh.md
+++ b/reference/static/commands/shells/chsh.md
@@ -3,6 +3,8 @@ chsh
 
 The chsh command allows a user to change the local login shell. The command accepts a filename as an input where a valid shell is stored in the machine. If no shell is found or no valid filename is given, the command will prompt for a valid filename/shell.
 
+The change takes effect the next time the user logs in.
+
 ~~~ bash
 $ chsh [-s login_shell] [-l] [-h] [-v] [username] 
 ~~~
@@ -23,4 +25,6 @@ chsh -s /bin/zsh Bob
 
 Sets user Bob's login shell to zsh located in /bin/zsh
 
-It can also be configured to accept only shells listed in this file (unless the user is root). If a shell is not specified, chsh will prompt for one to be specified.
+chsh will accept the full pathname of any executable file on the system. However, it will issue a warning if the shell is not listed in the /etc/shells file. It can also be configured to accept only shells listed in this file (unless the user is root). If a shell is not specified, chsh will prompt for one to be specified.
+
+Some related commands include, chfn - change a user's finger information, usermod - change a user's account and passwd - change a user's password.

--- a/reference/static/commands/shells/chsh.md
+++ b/reference/static/commands/shells/chsh.md
@@ -3,11 +3,11 @@ chsh
 
 The chsh command allows a user to change the local login shell. The command accepts a filename as an input where a valid shell is stored in the machine. If no shell is found or no valid filename is given, the command will prompt for a valid filename/shell.
 
-### Syntax 
-~~~bash
-chsh [-s login_shell] [-l] [-h] [-v] [username] 
+~~~ bash
+$ chsh [-s login_shell] [-l] [-h] [-v] [username] 
 ~~~
 
+---
 ### Options
  * `-s login_shell`   Sets login_shell as current shell
  * `-l`     Prints list of shells in /etc/shells for Linux machines
@@ -22,3 +22,5 @@ chsh -s /bin/zsh Bob
 ~~~
 
 Sets user Bob's login shell to zsh located in /bin/zsh
+
+It can also be configured to accept only shells listed in this file (unless the user is root). If a shell is not specified, chsh will prompt for one to be specified.


### PR DESCRIPTION
# Advanced HW 5 submission

Closes #157 


Name: Prathit Shukla
Uniqname: prathit

## Description of Changes
Fixed formatting of the chsh on the main website

The formatting before was incorrect due to the previous editor making a mistake in Markdown forgetting to put the advanced options on the link of the page. Instead it was put on the preview of this tag which is now fixed.
Also added additional documentation for different options

