### PR TITLE
Logname Files-Useful Command line-Telling your current log in name

### DIFF
--- a/reference/static/commands/tools/logname.md
+++ b/reference/static/commands/tools/logname.md
@@ -29,5 +29,5 @@
 -------
 ## Difference between logname and similar commands
 
-#### *It returns the current login name even in the sudo mode, while other commands, such as `whoami`, cannot do*
+It returns the current login name even in the sudo mode, while other commands, such as `whoami`, cannot do
 

--- a/reference/static/commands/tools/logname.md
+++ b/reference/static/commands/tools/logname.md
@@ -2,7 +2,7 @@
 
 ## logname gives the current login name
 
-###  *logname is really useful regarding finding out if you are working under a correct time*
+####  *logname is really useful regarding finding out if you are working under a correct time*
 
 * Especially for public computers. it is easy to edit on someone else's work
 
@@ -12,22 +12,22 @@
 
 -------
 
-###  *Logname is also important if our computer has different lognames for different projects or work*
+####  *Logname is also important if our computer has different lognames for different projects or work*
 
 * Working on the wrong project could aslo trigger substantial risks for our work and career
 
 * Checking logname is even important for checking our own laptop if we have different lognames
+------
+##  How to use logname
 
-#  How to use logname
-
-## You simply run logname without any other arguments, and it will print the current user name
+####  You simply run logname without any other arguments, and it will print the current user name
 
 `$ logname`
 
 *output: `Your current login name*
 
 -------
-# Difference between logname and similar commands
+## Difference between logname and similar commands
 
- * It returns the current login name even in the sudo mode, while other commands, such as `whoami`, cannot do
+#### *It returns the current login name even in the sudo mode, while other commands, such as `whoami`, cannot do*
 

--- a/reference/static/commands/tools/logname.md
+++ b/reference/static/commands/tools/logname.md
@@ -1,23 +1,33 @@
-#  logname
----------
-**logname gives the current login name**
+# Logname
+
+## logname gives the current login name
+
+###  *logname is really useful regarding finding out if you are working under a correct time*
+
+* Especially for public computers. it is easy to edit on someone else's work
+
+* Working under a wrong name expose your work and others work in substantial risks
+
+* We should all have a habit of checking if our logname is correct in a public computer
+
 -------
 
-**logname is really useful regarding finding out if you are working under a correct time**
---------
-** Especially for public computers. it is easy to edit on someone else's work**
---------
-**Working under a wrong name expose your work and others work in substantial risks**
----------
-** We should all have a habit of checking if our logname is correct in a public computer**
--------
-**Logname is also important if our computer has different lognames for different projects or work**
------
-**Working on the wrong project could aslo trigger substantial risks for our work and career**
-------
-**Checking logname is even important for checking our own laptop if we have different lognames**
--------
-## Example Command
+###  *Logname is also important if our computer has different lognames for different projects or work*
 
-# $ logname 
-# output: Your current login name 
+* Working on the wrong project could aslo trigger substantial risks for our work and career
+
+* Checking logname is even important for checking our own laptop if we have different lognames
+
+#  How to use logname
+
+## You simply run logname without any other arguments, and it will print the current user name
+
+`$ logname`
+
+*output: `Your current login name*
+
+-------
+# Difference between logname and similar commands
+
+ * It returns the current login name even in the sudo mode, while other commands, such as `whoami`, cannot do
+

--- a/reference/static/commands/tools/logname.md
+++ b/reference/static/commands/tools/logname.md
@@ -24,7 +24,7 @@
 
 `$ logname`
 
-*output: `Your current login name*
+*output: `Your current login name`*
 
 -------
 ## Difference between logname and similar commands

--- a/reference/static/commands/tools/logname.md
+++ b/reference/static/commands/tools/logname.md
@@ -1,0 +1,23 @@
+#  logname
+---------
+**logname gives the current login name**
+-------
+
+**logname is really useful regarding finding out if you are working under a correct time**
+--------
+** Especially for public computers. it is easy to edit on someone else's work**
+--------
+**Working under a wrong name expose your work and others work in substantial risks**
+---------
+** We should all have a habit of checking if our logname is correct in a public computer**
+-------
+**Logname is also important if our computer has different lognames for different projects or work**
+-----
+**Working on the wrong project could aslo trigger substantial risks for our work and career**
+------
+**Checking logname is even important for checking our own laptop if we have different lognames**
+-------
+## Example Command
+
+# $ logname 
+# output: Your current login name 


### PR DESCRIPTION
# Advanced HW 5 submission

Closes #[183]

Name: [Kun Yan]
Uniqname: [kuny]

#### I added logname issue. That will give the current login name. It is important because it keeps users from using the wrong log in names on a public computer. It also works in the sudo mode as other similar commands, such as `whoami`, cannot do.



